### PR TITLE
Feature: PDF do edital será salvo no banco

### DIFF
--- a/app/Http/Controllers/ProcessController.php
+++ b/app/Http/Controllers/ProcessController.php
@@ -75,7 +75,7 @@ class ProcessController extends Controller
                 'descricao' => 'required|string|max:255',
                 'status' => 'required|in:Pendente,Aberto,Fechado',
                 'numero_processo' => 'required|string|max:255',
-                'edital' => 'nullable|string|max:255',
+                'edital' => 'nullable|file|mimes:pdf|max:204800', // 200MB max
                 'data_inicio' => 'required|date',
                 'data_fim' => 'nullable|date',
             ]);


### PR DESCRIPTION
Agora ao cadastrar o processo com o PDF do edital ele será salvo no banco de dados com um caminho (storage/app/private/editais). O tamnho máximo do PDF é de 200MB